### PR TITLE
Add create-status-check option for CI code coverage results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,5 +65,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           summary-file: 'coverage-results/Summary.md'
           create-pr-comment: true
+          create-status-check: true
           update-comment-if-one-exists: true
           update-comment-key: 'jest'


### PR DESCRIPTION
Introduce a new option to create a status check for code coverage results in the CI workflow. This enhances visibility into coverage metrics directly within pull requests.